### PR TITLE
Create type electron workflow

### DIFF
--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -1,0 +1,148 @@
+name: Create TypeScript Electron Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo_name:
+        description: 'Repository name'
+        required: true
+      description:
+        description: 'Repository description'
+        required: false
+        default: 'An Electron application built with TypeScript'
+      author_name:
+        description: 'Author name'
+        required: true
+      author_email:
+        description: 'Author email'
+        required: true
+      ts_target:
+        description: 'TypeScript target'
+        required: false
+        default: 'ES2024'
+      ts_module:
+        description: 'TypeScript module system'
+        required: false
+        default: 'CommonJS'
+      ts_module_resolution:
+        description: 'TypeScript module resolution'
+        required: false
+        default: 'node'
+      private:
+        description: 'Private repository'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  create-electron-repository:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Step 1 - Checkout code
+      uses: actions/checkout@v3
+      
+    - name: Step 2 - Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x'
+        
+    - name: Step 3 - Generate Electron application
+      run: |
+        # Create Electron TypeScript project
+        npx create-electron-app "${{ github.event.inputs.repo_name }}"
+        
+        # Install additional dependencies
+        cd "${{ github.event.inputs.repo_name }}"
+        npm install --save-dev typescript @types/node electron-typescript-definitions copyfiles nodemon
+        
+        # Install js-to-ts-converter without saving to package.json
+        npm install js-to-ts-converter --no-save
+        
+        # Rename index.js to main.js if it exists
+        if [ -f "src/index.js" ]; then
+          mv src/index.js src/main.js
+          echo "Renamed src/index.js to src/main.js"
+          
+          # Update any references to index.js in other files
+          find src -type f -not -name "main.js" -exec sed -i 's/index\.js/main.js/g' {} \;
+        fi
+        
+        # Convert JS files to TS
+        echo "Converting JavaScript files to TypeScript..."
+        npx js-to-ts-converter src
+                
+        # Create custom tsconfig.json
+        cat > tsconfig.json << EOF
+        {
+          "compilerOptions": {
+            "target": "${{ github.event.inputs.ts_target }}",
+            "module": "${{ github.event.inputs.ts_module }}",
+            "moduleResolution": "${{ github.event.inputs.ts_module_resolution }}",
+            "outDir": "./dist",
+            "rootDir": "./src",
+            "strict": true,
+            "esModuleInterop": true,
+            "sourceMap": true,
+            "baseUrl": "."
+          },
+          "include": ["src/**/*"]
+        }
+        EOF
+        
+        # Modify package.json
+        cat > update_package.js << 'EOF'
+        const fs = require('fs');
+        const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+        
+        // Update author information
+        packageJson.author = {
+          name: "${{ github.event.inputs.author_name }}",
+          email: "${{ github.event.inputs.author_email }}"
+        };
+        
+        // Update description
+        packageJson.description = "${{ github.event.inputs.description }}";
+        
+        // Update main entry point
+        packageJson.main = "dist/main.js";
+        
+        // Update scripts
+        packageJson.scripts = {
+          ...packageJson.scripts,
+          "build": "tsc && copyfiles -u 1 src/**/*.html src/**/*.css src/assets/** dist/",
+          "watch": "tsc -w",
+          "start": "npm run build && electron-forge start",
+          "dev": "nodemon --exec \"npm run build && electron-forge start\" --watch src --ext ts,tsx,html,css"
+        };
+        
+        fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
+        EOF
+        
+        node update_package.js
+        rm update_package.js
+
+    - name: Step 4 - Create new GitHub repository
+      run: |
+        curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
+             -d '{
+                  "name": "${{ github.event.inputs.repo_name }}",
+                  "description": "${{ github.event.inputs.description }}",
+                  "private": ${{ github.event.inputs.private }}
+                }' \
+             https://api.github.com/user/repos
+
+    - name: Step 5 - Push to new repository
+      run: |
+        cd "${{ github.event.inputs.repo_name }}"
+        git config --global user.email "${{ github.event.inputs.author_email }}"
+        git config --global user.name "${{ github.event.inputs.author_name }}"
+        git init
+        git add .
+        git commit -m "Initialize Electron TypeScript project"
+        git branch -M main
+        git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
+        git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
+        git push -u origin main
+      env:
+        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation of a TypeScript-based Electron repository. The workflow includes several steps to set up the repository, configure TypeScript, and push the initial code to a new GitHub repository.

Key changes include:

### New Workflow for Repository Creation:

* [`.github/workflows/create-typescript-electron-repository.yaml`](diffhunk://#diff-575e892f06a6062c56fc4dbdfb1bfaf420b814774530148a2b4cbd7a0432969eR1-R148): Added a new workflow that triggers on `workflow_dispatch` to create a TypeScript Electron repository with configurable inputs such as `repo_name`, `description`, `author_name`, and `author_email`.

### Workflow Steps:

* **Step 1 - Checkout code**: Uses the `actions/checkout@v3` action to check out the repository code.
* **Step 2 - Setup Node.js**: Uses the `actions/setup-node@v3` action to set up Node.js version `18.x`.
* **Step 3 - Generate Electron application**: Runs a series of commands to create an Electron TypeScript project, install dependencies, convert JavaScript files to TypeScript, and update `package.json` with custom configurations.
* **Step 4 - Create new GitHub repository**: Uses a `curl` command to create a new GitHub repository using the provided inputs and personal access token. (Fdb