### PR TITLE
Update github namespace to innobridge

### DIFF
--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -141,7 +141,7 @@ jobs:
         git add .
         git commit -m "Initialize Electron TypeScript project"
         git branch -M main
-        git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
+        git remote add origin git@github.com:InnoBridge/${{ github.event.inputs.repo_name }}.git
         git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
         git push -u origin main
       env:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/create-typescript-electron-repository.yaml` file. The change updates the remote repository URL to use a specific organization instead of the GitHub actor's username.

* [`.github/workflows/create-typescript-electron-repository.yaml`](diffhunk://#diff-575e892f06a6062c56fc4dbdfb1bfaf420b814774530148a2b4cbd7a0432969eL144-R144): Updated the `git remote add origin` command to use `InnoBridge` as the organization for the repository URL.