### PR TITLE
Update change url to https://api.github.com/orgs/InnoBridge/repos

### DIFF
--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -130,7 +130,7 @@ jobs:
                   "description": "${{ github.event.inputs.description }}",
                   "private": ${{ github.event.inputs.private }}
                 }' \
-             https://api.github.com/user/repos
+             https://api.github.com/orgs/InnoBridge/repos
 
     - name: Step 5 - Push to new repository
       run: |


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/create-typescript-electron-repository.yaml` file to update the URL for creating a new repository. The change modifies the endpoint from the user-specific URL to the organization-specific URL.

* [`.github/workflows/create-typescript-electron-repository.yaml`](diffhunk://#diff-575e892f06a6062c56fc4dbdfb1bfaf420b814774530148a2b4cbd7a0432969eL133-R133): Updated the URL from `https://api.github.com/user/repos` to `https://api.github.com/orgs/InnoBridge/repos` to create repositories under the InnoBridge organization.