### PR TITLE
Update to user innobridge github url

### DIFF
--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -142,7 +142,7 @@ jobs:
         git commit -m "Initialize Electron TypeScript project"
         git branch -M main
         git remote add origin git@github.com:InnoBridge/${{ github.event.inputs.repo_name }}.git
-        git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
+        git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/InnoBridge/${{ github.event.inputs.repo_name }}
         git push -u origin main
       env:
         GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/create-typescript-electron-repository.yaml` file. The change updates the repository URL in the `git remote set-url` command to use the `InnoBridge` organization instead of the GitHub actor's username.

* [`.github/workflows/create-typescript-electron-repository.yaml`](diffhunk://#diff-575e892f06a6062c56fc4dbdfb1bfaf420b814774530148a2b4cbd7a0432969eL145-R145): Updated the repository URL in the `git remote set-url` command to use `InnoBridge` instead of `${{ github.actor }}`.