### PR TITLE
support for electron vite

### DIFF
--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -23,7 +23,10 @@ on:
         options:
           - electron-with-typescript
           - electron-forge-with-webpack
-        default: 'electron-with-typescript'
+          - vite-ts
+          - vite-react-ts
+          - vite-vue-ts
+        default: 'vite-ts'
       ts_target:
         description: 'TypeScript target'
         required: false
@@ -299,6 +302,50 @@ jobs:
         fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
         EOF
         
+        node update_package.js
+        rm update_package.js
+
+    - name: Step 3c - Generate Electron with Vite
+      if: ${{ startsWith(github.event.inputs.build_tool, 'vite-') }}
+      run: |
+        # Determine template based on build_tool selection
+        TEMPLATE=""
+        case "${{ github.event.inputs.build_tool }}" in
+          "vite-ts")
+            TEMPLATE="vanilla-ts"
+            ;;
+          "vite-react-ts")
+            TEMPLATE="react-ts"
+            ;;
+          "vite-vue-ts")
+            TEMPLATE="vue-ts"
+            ;;
+        esac
+        
+        # Convert repo name to lowercase for compatibility with electron-vite
+        REPO_NAME_LOWER=$(echo "${{ github.event.inputs.repo_name }}" | tr '[:upper:]' '[:lower:]')
+
+        # Create Electron app with selected template
+        npm create @quick-start/electron "$REPO_NAME_LOWER" -- --template $TEMPLATE --skip
+
+        # If repo name is different than lowercase version, rename directory
+        if [ "$REPO_NAME_LOWER" != "${{ github.event.inputs.repo_name }}" ]; then
+          mv "$REPO_NAME_LOWER" "${{ github.event.inputs.repo_name }}"
+        fi
+
+        cd "${{ github.event.inputs.repo_name }}"
+        
+        # Update package.json with metadata
+        cat > update_package.js << 'EOF'
+        const fs = require('fs');
+        const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+        packageJson.author = {
+          name: "${{ github.event.inputs.author_name }}",
+          email: "${{ github.event.inputs.author_email }}"
+        };
+        packageJson.description = "${{ github.event.inputs.description }}";
+        fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
+        EOF
         node update_package.js
         rm update_package.js
 


### PR DESCRIPTION
This pull request includes significant updates to the `.github/workflows/create-typescript-electron-repository.yaml` file to support new build tool options and generate Electron apps with Vite templates. The most important changes include adding new Vite options, modifying the default option, and implementing a new job step for generating Electron apps with Vite.

### Updates to build tool options:

* Added new build tool options: `vite-ts`, `vite-react-ts`, and `vite-vue-ts`. Modified the default option to `vite-ts`. (`.github/workflows/create-typescript-electron-repository.yaml`)

### New job step for Electron with Vite:

* Implemented a new job step to generate Electron apps using Vite templates based on the selected build tool. This includes determining the appropriate template, creating the Electron app, updating `package.json` with metadata, and handling repository naming compatibility. (`.github/workflows/create-typescript-electron-repository.yaml`)