### PR TITLE
workflow to create react native app with expo

### DIFF
--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -1,0 +1,63 @@
+name: Create React Native App Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: 'Name of the React Native app'
+        required: true
+        type: string
+      description:
+        description: 'Repository description'
+        required: false
+        default: 'A React Native app created with Expo'
+      author_name:
+        description: 'Author name'
+        required: true
+        type: string
+      author_email:
+        description: 'Author email'
+        required: true
+        type: string
+      private:
+        description: 'Private repository'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  create-react-native-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          
+      - name: Create React Native app
+        run: npx create-expo-app ${{ github.event.inputs.app_name }}
+
+      - name: Create new GitHub repository
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
+            -d '{
+                  "name": "${{ github.event.inputs.app_name }}",
+                  "description": "${{ github.event.inputs.description }}",
+                  "private": ${{ github.event.inputs.private }}
+                }' \
+            https://api.github.com/orgs/InnoBridge/repos
+
+      - name: Push to new repository
+        run: |
+          cd "${{ github.event.inputs.app_name }}"
+          git config --global user.email "${{ github.event.inputs.author_email }}"
+          git config --global user.name "${{ github.event.inputs.author_name }}"
+          git init
+          git add .
+          git commit -m "Initialize React Native app with Expo"
+          git branch -M main
+          git remote add origin git@github.com:InnoBridge/${{ github.event.inputs.app_name }}.git
+          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/InnoBridge/${{ github.event.inputs.app_name }}
+          git push -u origin main
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation of a React Native app repository. The workflow allows users to specify app details, generates a React Native app using Expo, creates a new GitHub repository, and pushes the initialized app to the repository.

### New GitHub Actions Workflow:

* **Workflow file**: Added `.github/workflows/create-react-native-app-repository.yaml` to define a new workflow named "Create React Native App Repository."
* **Inputs**: Configured inputs for app name, description, author name, author email, and repository privacy settings to customize the app and repository creation process.
* **Steps**:
  * Set up Node.js environment using `actions/setup-node@v3`.
  * Generate a React Native app with Expo using the `npx create-expo-app` command.
  * Create a new GitHub repository via the GitHub API, using a personal access token for authentication.
  * Initialize a Git repository, configure user details, and push the app to the newly created repository.