### PR TITLE
Create node workflow

### DIFF
--- a/.github/workflows/create-node-backend.yaml
+++ b/.github/workflows/create-node-backend.yaml
@@ -1,0 +1,96 @@
+name: Create Node Backend Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo_name:
+        description: 'Name of the backend repository'
+        required: true
+        type: string
+      description:
+        description: 'Repository description'
+        required: false
+        default: 'A Node.js backend with Express'
+      author_name:
+        description: 'Author name'
+        required: true
+        type: string
+      author_email:
+        description: 'Author email'
+        required: true
+        type: string
+      private:
+        description: 'Private repository'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  create-node-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+
+      - name: Scaffold TypeScript Express backend
+        run: |
+          # create project directory and init
+          mkdir "${{ github.event.inputs.repo_name }}"
+          cd "${{ github.event.inputs.repo_name }}"
+          npm init -y
+
+          # install runtime & dev dependencies
+          npm install express
+          npm install --save-dev typescript ts-node-dev @types/node @types/express
+
+          # write tsconfig.json
+          cat << 'EOF' > tsconfig.json
+          {
+            "compilerOptions": {
+              "target": "ES2020",
+              "module": "CommonJS",
+              "rootDir": "src",
+              "outDir": "dist",
+              "strict": true,
+              "esModuleInterop": true,
+              "skipLibCheck": true
+            }
+          }
+          EOF
+
+          # create src folder and empty entrypoint
+          mkdir src
+          touch src/index.ts
+
+          # define npm scripts
+          npm pkg set scripts.dev="ts-node-dev --respawn --transpile-only src/index.ts"
+          npm pkg set scripts.build="tsc"
+          npm pkg set scripts.start="node dist/index.js"
+
+
+      - name: Create new GitHub repository
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
+            -d '{
+                  "name": "${{ github.event.inputs.app_name }}",
+                  "description": "${{ github.event.inputs.description }}",
+                  "private": ${{ github.event.inputs.private }}
+                }' \
+            https://api.github.com/user/repos
+
+      - name: Push to new repository
+        run: |
+          cd "${{ github.event.inputs.app_name }}"
+          git config --global user.email "${{ github.event.inputs.author_email }}"
+          git config --global user.name "${{ github.event.inputs.author_name }}"
+          git init
+          git add .
+          git commit -m "Initialize React Native app with Expo"
+          git branch -M main
+          git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.app_name }}.git
+          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.app_name }}
+          git push -u origin main
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -61,12 +61,12 @@ jobs:
           cd "${{ github.event.inputs.app_name }}"
           git config --global user.email "${{ github.event.inputs.author_email }}"
           git config --global user.name "${{ github.event.inputs.author_name }}"
-            git init
-            git add .
-            git commit -m "Initialize Electron project with ${{ github.event.inputs.build_tool }}"
-            git branch -M main
-            git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
-            git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
-            git push -u origin main
-          env:
-            GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          git init
+          git add .
+          git commit -m "Initialize Electron project with ${{ github.event.inputs.build_tool }}"
+          git branch -M main
+          git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
+          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
+          git push -u origin main
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -37,15 +37,6 @@ jobs:
       - name: Create React Native app
         run: npx create-expo-app ${{ github.event.inputs.app_name }}
 
-      - name: Initialize git repository
-        run: |
-          cd ${{ github.event.inputs.app_name }}
-          git init
-          git add .
-          git config --global user.email "${{ github.event.inputs.author_email }}"
-          git config --global user.name "${{ github.event.inputs.author_name }}"
-          git commit -m "Initial commit: Create React Native app with Expo"
-
       - name: Create new GitHub repository
         run: |
           curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
@@ -63,10 +54,10 @@ jobs:
           git config --global user.name "${{ github.event.inputs.author_name }}"
           git init
           git add .
-          git commit -m "Initialize Electron project with ${{ github.event.inputs.build_tool }}"
+          git commit -m "Initialize React Native app with Expo"
           git branch -M main
-          git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
-          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
+          git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.app_name }}.git
+          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.app_name }}
           git push -u origin main
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
             -d '{
-                  "name": "${{ github.event.inputs.repo_name }}",
+                  "name": "${{ github.event.inputs.app_name }}",
                   "description": "${{ github.event.inputs.description }}",
                   "private": ${{ github.event.inputs.private }}
                 }' \

--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -1,0 +1,72 @@
+name: Create React Native App Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: 'Name of the React Native app'
+        required: true
+        type: string
+      description:
+        description: 'Repository description'
+        required: false
+        default: 'A React Native app created with Expo'
+      author_name:
+        description: 'Author name'
+        required: true
+        type: string
+      author_email:
+        description: 'Author email'
+        required: true
+        type: string
+      private:
+        description: 'Private repository'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  create-react-native-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          
+      - name: Create React Native app
+        run: npx create-expo-app ${{ github.event.inputs.app_name }}
+
+      - name: Initialize git repository
+        run: |
+          cd ${{ github.event.inputs.app_name }}
+          git init
+          git add .
+          git config --global user.email "${{ github.event.inputs.author_email }}"
+          git config --global user.name "${{ github.event.inputs.author_name }}"
+          git commit -m "Initial commit: Create React Native app with Expo"
+
+      - name: Create new GitHub repository
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
+            -d '{
+                  "name": "${{ github.event.inputs.repo_name }}",
+                  "description": "${{ github.event.inputs.description }}",
+                  "private": ${{ github.event.inputs.private }}
+                }' \
+            https://api.github.com/user/repos
+
+      - name: Push to new repository
+        run: |
+          cd "${{ github.event.inputs.app_name }}"
+          git config --global user.email "${{ github.event.inputs.author_email }}"
+          git config --global user.name "${{ github.event.inputs.author_name }}"
+            git init
+            git add .
+            git commit -m "Initialize Electron project with ${{ github.event.inputs.build_tool }}"
+            git branch -M main
+            git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
+            git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
+            git push -u origin main
+          env:
+            GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -56,6 +56,22 @@ jobs:
         cd "${{ github.event.inputs.repo_name }}"
         npm install --save-dev typescript @types/node electron-typescript-definitions copyfiles nodemon
         
+        # Install js-to-ts-converter without saving to package.json
+        npm install js-to-ts-converter --no-save
+        
+        # Rename index.js to main.js if it exists
+        if [ -f "src/index.js" ]; then
+          mv src/index.js src/main.js
+          echo "Renamed src/index.js to src/main.js"
+          
+          # Update any references to index.js in other files
+          find src -type f -not -name "main.js" -exec sed -i 's/index\.js/main.js/g' {} \;
+        fi
+        
+        # Convert JS files to TS
+        echo "Converting JavaScript files to TypeScript..."
+        npx js-to-ts-converter src
+                
         # Create custom tsconfig.json
         cat > tsconfig.json << EOF
         {
@@ -87,6 +103,9 @@ jobs:
         
         // Update description
         packageJson.description = "${{ github.event.inputs.description }}";
+        
+        // Update main entry point
+        packageJson.main = "dist/main.js";
         
         // Update scripts
         packageJson.scripts = {

--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -28,6 +28,11 @@ on:
         description: 'TypeScript module resolution'
         required: false
         default: 'node'
+      private:
+        description: 'Private repository'
+        required: false
+        default: 'false'
+        type: boolean
 
 jobs:
   create-electron-repository:
@@ -102,7 +107,7 @@ jobs:
       run: |
         curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
              -d '{
-                  "name": "${{ github.event.inputs.name }}",
+                  "name": "${{ github.event.inputs.repo_name }}",
                   "description": "${{ github.event.inputs.description }}",
                   "private": ${{ github.event.inputs.private }}
                 }' \
@@ -110,17 +115,15 @@ jobs:
 
     - name: Step 5 - Push to new repository
       run: |
-        cd spring-boot-project
-        echo "# ${{  github.event.inputs.name }}" >> README.md
-        git config --global user.email "${{ github.event.inputs.userEmail }}"
-        git config --global user.name "${{ github.event.inputs.userName }}"
+        cd "${{ github.event.inputs.repo_name }}"
+        git config --global user.email "${{ github.event.inputs.author_email }}"
+        git config --global user.name "${{ github.event.inputs.author_name }}"
         git init
         git add .
-        git add README.md
-        git commit -m "first commit"
+        git commit -m "Initialize Electron TypeScript project"
         git branch -M main
-        git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.name }}.git
-        git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.name }}
-        git push -u origin main  # Push to 'main' branch
+        git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
+        git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
+        git push -u origin main
       env:
         GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -322,8 +322,17 @@ jobs:
             ;;
         esac
         
+        # Convert repo name to lowercase for compatibility with electron-vite
+        REPO_NAME_LOWER=$(echo "${{ github.event.inputs.repo_name }}" | tr '[:upper:]' '[:lower:]')
+
         # Create Electron app with selected template
-        npm create @quick-start/electron "${{ github.event.inputs.repo_name }}" -- --template $TEMPLATE
+        npm create @quick-start/electron "$REPO_NAME_LOWER" -- --template $TEMPLATE --skip
+
+        # If repo name is different than lowercase version, rename directory
+        if [ "$REPO_NAME_LOWER" != "${{ github.event.inputs.repo_name }}" ]; then
+          mv "$REPO_NAME_LOWER" "${{ github.event.inputs.repo_name }}"
+        fi
+
         cd "${{ github.event.inputs.repo_name }}"
         
         # Update package.json with metadata

--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -202,15 +202,15 @@ jobs:
         cat > tsconfig.json << 'EOF'
         {
           "compilerOptions": {
-            "target": "ES2021",
-            "module": "commonjs",
+            "target": "${{ github.event.inputs.ts_target }}",
+            "module": "${{ github.event.inputs.ts_module }}",
             "esModuleInterop": true
           },
           "include": ["src/**/*"]
         }
         EOF
         
-        # Update forge.config.js to use TypeScript files
+        # Update forge.config.js to use TypeScript files and add fuses plugin
         cat > update_forge_config.js << 'EOF'
         const fs = require('fs');
         const forgeConfig = require('./forge.config.js');
@@ -233,6 +233,35 @@ jobs:
             ];
           }
         }
+        
+        // Add the fuses plugin if it doesn't already exist
+        if (!forgeConfig.plugins.some(plugin => plugin.name === '@electron-forge/plugin-fuses')) {
+          forgeConfig.plugins.push({
+            "name": "@electron-forge/plugin-fuses",
+            "config": {
+              "version": 1,
+              "fuses": {
+                "runAsNode": false,
+                "enableNodeCliInspectArguments": true,
+                "enableEmbeddedAsarIntegrityValidation": false,
+                "onlyLoadAppFromAsar": false,
+                "loadBrowserProcessSpecificV8Snapshot": true,
+                "enableCookieEncryption": true
+              }
+            }
+          });
+        }
+
+        // White listed plugins
+        whitelist_plugin_names = [
+          "@electron-forge/plugin-auto-unpack-natives",
+          "@electron-forge/plugin-webpack",
+          "@electron-forge/plugin-fuses"
+        ];
+
+        // Remove any plugins that are not in the whitelist
+        forgeConfig.plugins = forgeConfig.plugins.filter(plugin => 
+          whitelist_plugin_names.includes(plugin.name));
         
         fs.writeFileSync('./forge.config.js', 
           `module.exports = ${JSON.stringify(forgeConfig, null, 2)}`);

--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -1,0 +1,126 @@
+name: Create TypeScript Electron Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo_name:
+        description: 'Repository name'
+        required: true
+      description:
+        description: 'Repository description'
+        required: false
+        default: 'An Electron application built with TypeScript'
+      author_name:
+        description: 'Author name'
+        required: true
+      author_email:
+        description: 'Author email'
+        required: true
+      ts_target:
+        description: 'TypeScript target'
+        required: false
+        default: 'ES2024'
+      ts_module:
+        description: 'TypeScript module system'
+        required: false
+        default: 'CommonJS'
+      ts_module_resolution:
+        description: 'TypeScript module resolution'
+        required: false
+        default: 'node'
+
+jobs:
+  create-electron-repository:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Step 1 - Checkout code
+      uses: actions/checkout@v3
+      
+    - name: Step 2 - Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x'
+        
+    - name: Step 3 - Generate Electron application
+      run: |
+        # Create Electron TypeScript project
+        npx create-electron-app "${{ github.event.inputs.repo_name }}" --template=typescript
+        
+        # Install additional dependencies
+        cd "${{ github.event.inputs.repo_name }}"
+        npm install --save-dev typescript @types/node electron-typescript-definitions copyfiles nodemon
+        
+        # Create custom tsconfig.json
+        cat > tsconfig.json << EOF
+        {
+          "compilerOptions": {
+            "target": "${{ github.event.inputs.ts_target }}",
+            "module": "${{ github.event.inputs.ts_module }}",
+            "moduleResolution": "${{ github.event.inputs.ts_module_resolution }}",
+            "outDir": "./dist",
+            "rootDir": "./src",
+            "strict": true,
+            "esModuleInterop": true,
+            "sourceMap": true,
+            "baseUrl": "."
+          },
+          "include": ["src/**/*"]
+        }
+        EOF
+        
+        # Modify package.json
+        cat > update_package.js << 'EOF'
+        const fs = require('fs');
+        const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+        
+        // Update author information
+        packageJson.author = {
+          name: "${{ github.event.inputs.author_name }}",
+          email: "${{ github.event.inputs.author_email }}"
+        };
+        
+        // Update description
+        packageJson.description = "${{ github.event.inputs.description }}";
+        
+        // Update scripts
+        packageJson.scripts = {
+          ...packageJson.scripts,
+          "build": "tsc && copyfiles -u 1 src/**/*.html src/**/*.css src/assets/** dist/",
+          "watch": "tsc -w",
+          "start": "npm run build && electron-forge start",
+          "dev": "nodemon --exec \"npm run build && electron-forge start\" --watch src --ext ts,tsx,html,css"
+        };
+        
+        fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
+        EOF
+        
+        node update_package.js
+        rm update_package.js
+
+    - name: Step 4 - Create new GitHub repository
+      run: |
+        curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
+             -d '{
+                  "name": "${{ github.event.inputs.name }}",
+                  "description": "${{ github.event.inputs.description }}",
+                  "private": ${{ github.event.inputs.private }}
+                }' \
+             https://api.github.com/user/repos
+
+    - name: Step 5 - Push to new repository
+      run: |
+        cd spring-boot-project
+        echo "# ${{  github.event.inputs.name }}" >> README.md
+        git config --global user.email "${{ github.event.inputs.userEmail }}"
+        git config --global user.name "${{ github.event.inputs.userName }}"
+        git init
+        git add .
+        git add README.md
+        git commit -m "first commit"
+        git branch -M main
+        git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.name }}.git
+        git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.name }}
+        git push -u origin main  # Push to 'main' branch
+      env:
+        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -50,7 +50,7 @@ jobs:
     - name: Step 3 - Generate Electron application
       run: |
         # Create Electron TypeScript project
-        npx create-electron-app "${{ github.event.inputs.repo_name }}" --template=typescript
+        npx create-electron-app "${{ github.event.inputs.repo_name }}"
         
         # Install additional dependencies
         cd "${{ github.event.inputs.repo_name }}"

--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -23,7 +23,10 @@ on:
         options:
           - electron-with-typescript
           - electron-forge-with-webpack
-        default: 'electron-with-typescript'
+          - vite-ts
+          - vite-react-ts
+          - vite-vue-ts
+        default: 'vite-ts'
       ts_target:
         description: 'TypeScript target'
         required: false
@@ -299,6 +302,41 @@ jobs:
         fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
         EOF
         
+        node update_package.js
+        rm update_package.js
+
+    - name: Step 3c - Generate Electron with Vite
+      if: ${{ startsWith(github.event.inputs.build_tool, 'vite-') }}
+      run: |
+        # Determine template based on build_tool selection
+        TEMPLATE=""
+        case "${{ github.event.inputs.build_tool }}" in
+          "vite-ts")
+            TEMPLATE="vanilla-ts"
+            ;;
+          "vite-react-ts")
+            TEMPLATE="react-ts"
+            ;;
+          "vite-vue-ts")
+            TEMPLATE="vue-ts"
+            ;;
+        esac
+        
+        # Create Electron app with selected template
+        npm create @quick-start/electron "${{ github.event.inputs.repo_name }}" -- --template $TEMPLATE
+        cd "${{ github.event.inputs.repo_name }}"
+        
+        # Update package.json with metadata
+        cat > update_package.js << 'EOF'
+        const fs = require('fs');
+        const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+        packageJson.author = {
+          name: "${{ github.event.inputs.author_name }}",
+          email: "${{ github.event.inputs.author_email }}"
+        };
+        packageJson.description = "${{ github.event.inputs.description }}";
+        fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
+        EOF
         node update_package.js
         rm update_package.js
 

--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -16,6 +16,14 @@ on:
       author_email:
         description: 'Author email'
         required: true
+      build_tool:
+        description: 'Choose Your Build Tool'
+        required: true
+        type: choice
+        options:
+          - electron-with-typescript
+          - electron-forge-with-webpack
+        default: 'electron-with-typescript'
       ts_target:
         description: 'TypeScript target'
         required: false
@@ -47,7 +55,8 @@ jobs:
       with:
         node-version: '18.x'
         
-    - name: Step 3 - Generate Electron application
+    - name: Step 3 - Generate Electron with TypeScript
+      if: ${{ github.event.inputs.build_tool == 'electron-with-typescript' || github.event.inputs.build_tool == '' }}
       run: |
         # Create Electron TypeScript project
         npx create-electron-app "${{ github.event.inputs.repo_name }}"
@@ -122,6 +131,147 @@ jobs:
         node update_package.js
         rm update_package.js
 
+    - name: Step 3b - Generate Electron with Forge and Webpack
+      if: ${{ github.event.inputs.build_tool == 'electron-forge-with-webpack' }}
+      run: |
+        # Create Electron app with webpack template
+        npx create-electron-app "${{ github.event.inputs.repo_name }}" --template=webpack
+        cd "${{ github.event.inputs.repo_name }}"
+        
+        # Install TypeScript and related dependencies
+        npm install --save-dev typescript ts-loader
+        npm install --save-dev style-loader css-loader
+        npm install --save-dev sass sass-loader
+        
+        # Install js-to-ts-converter without saving to package.json
+        npm install js-to-ts-converter --no-save
+        
+        # Convert JS files to TS
+        npx js-to-ts-converter src
+        
+        # Update webpack.main.config.js for TypeScript
+        cat > webpack.main.config.js << 'EOF'
+        module.exports = {
+          entry: './src/main.ts',
+          module: {
+            rules: [
+              {
+                test: /\.tsx?$/,
+                use: 'ts-loader',
+                exclude: /node_modules/,
+              },
+            ],
+          },
+          resolve: {
+            extensions: ['.tsx', '.ts', '.js'],
+          },
+        };
+        EOF
+        
+        # Update webpack.renderer.config.js for TypeScript and CSS
+        cat > webpack.renderer.config.js << 'EOF'
+        module.exports = {
+          module: {
+            rules: [
+              {
+                test: /\.tsx?$/,
+                use: 'ts-loader',
+                exclude: /node_modules/,
+              },
+              {
+                test: /\.s[ac]ss$/i,
+                use: ['style-loader', 'css-loader', 'sass-loader'],
+              },
+              {
+                test: /\.css$/i,
+                use: ['style-loader', 'css-loader'],
+              },
+              {
+                test: /\.(png|svg|jpg|jpeg|gif)$/i,
+                type: 'asset/resource',
+              },
+            ],
+          },
+          resolve: {
+            extensions: ['.tsx', '.ts', '.js'],
+          },
+        };
+        EOF
+        
+        # Create a basic tsconfig.json
+        cat > tsconfig.json << 'EOF'
+        {
+          "compilerOptions": {
+            "target": "ES2021",
+            "module": "commonjs",
+            "esModuleInterop": true
+          },
+          "include": ["src/**/*"]
+        }
+        EOF
+        
+        # Update forge.config.js to use TypeScript files
+        cat > update_forge_config.js << 'EOF'
+        const fs = require('fs');
+        const forgeConfig = require('./forge.config.js');
+        
+        // Update entry points to use TypeScript files
+        if (forgeConfig.plugins && forgeConfig.plugins.length > 0) {
+          const webpackPlugin = forgeConfig.plugins.find(plugin => 
+            plugin.name === '@electron-forge/plugin-webpack');
+            
+          if (webpackPlugin && webpackPlugin.config && webpackPlugin.config.mainConfig) {
+            webpackPlugin.config.renderer.entryPoints = [
+              {
+                name: 'main_window',
+                html: './src/index.html',
+                js: './src/renderer.ts',
+                preload: {
+                  js: './src/preload.ts',
+                },
+              },
+            ];
+          }
+        }
+        
+        fs.writeFileSync('./forge.config.js', 
+          `module.exports = ${JSON.stringify(forgeConfig, null, 2)}`);
+        EOF
+        
+        node update_forge_config.js
+        rm update_forge_config.js
+        
+        # Add TypeScript declarations in main.ts
+        echo "// TypeScript declarations for Electron Forge Webpack" > src/declarations.d.ts
+        echo "declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;" >> src/declarations.d.ts
+        echo "declare const MAIN_WINDOW_WEBPACK_ENTRY: string;" >> src/declarations.d.ts
+        
+        # Update main.ts to import declarations
+        sed -i '1i/// <reference path="./declarations.d.ts" />' src/main.ts
+        
+        # Modify package.json
+        cat > update_package.js << 'EOF'
+        const fs = require('fs');
+        const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+        
+        // Update author information
+        packageJson.author = {
+          name: "${{ github.event.inputs.author_name }}",
+          email: "${{ github.event.inputs.author_email }}"
+        };
+        
+        // Update description
+        packageJson.description = "${{ github.event.inputs.description }}";
+        
+        // For webpack template, we don't need to update main entry point or scripts
+        // as they are already correctly configured by the template
+        
+        fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
+        EOF
+        
+        node update_package.js
+        rm update_package.js
+
     - name: Step 4 - Create new GitHub repository
       run: |
         curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
@@ -139,7 +289,7 @@ jobs:
         git config --global user.name "${{ github.event.inputs.author_name }}"
         git init
         git add .
-        git commit -m "Initialize Electron TypeScript project"
+        git commit -m "Initialize Electron project with ${{ github.event.inputs.build_tool }}"
         git branch -M main
         git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
         git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}

--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -142,6 +142,7 @@ jobs:
         npm install --save-dev typescript ts-loader
         npm install --save-dev style-loader css-loader
         npm install --save-dev sass sass-loader
+        npm install --save-dev electron-forge
         
         # Install js-to-ts-converter without saving to package.json
         npm install js-to-ts-converter --no-save

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -40,7 +40,7 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
-          npx create-ts-fast@latest "{{ github.event.inputs.package_name }}" -- --template universal
+          npx create-ts-fast@latest "${{ github.event.inputs.package_name }}" -- --template universal
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -40,7 +40,7 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
-          npx tsdx create "${{ github.event.inputs.repo_name }}" --template ts --yes
+          npx tsdx create "${{ github.event.inputs.repo_name }}" --template basic --y
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set description="${{ github.event.inputs.description }}"

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -40,7 +40,7 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
-          npx -y create-ts-fast@latest "${{ github.event.inputs.package_name }}" -- --template universal --yes
+          npx create-ts-fast@latest "${{ github.event.inputs.repo_name }}" -- --template universal --yes
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -39,12 +39,14 @@ jobs:
           node-version: '18.x'
           
       - name: Scaffold TypeScript library
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
         run: |
-          export npm_config_init_author_name="${{ github.event.inputs.author_name }}"
-          export npm_config_init_author_email="${{ github.event.inputs.author_email }}"
-          npx tsdx create "${{ github.event.inputs.repo_name }}" --template basic --y
+          npx create-ts-fast@latest "{{ github.event.inputs.package_name }}"  -- --template universal
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
+          npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"          npm pkg set license="InnoBridge"
           npm pkg set description="${{ github.event.inputs.description }}"
           npm install
       

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -39,14 +39,12 @@ jobs:
           node-version: '18.x'
           
       - name: Scaffold TypeScript library
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
         run: |
-          npx create-ts-fast@latest "{{ github.event.inputs.package_name }}"  -- --template universal
+          npx create-ts-fast@latest "{{ github.event.inputs.package_name }}" -- --template universal
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
-          npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"          npm pkg set license="InnoBridge"
+          npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"
+          npm pkg set license="InnoBridge"
           npm pkg set description="${{ github.event.inputs.description }}"
           npm install
       

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -40,12 +40,19 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
-          npx create-ts-fast@latest "${{ github.event.inputs.repo_name }}" --template universal --yes
+          # Non-interactive copy of your template
+          npx degit yilengyao/create-ts-fast-template "${{ github.event.inputs.repo_name }}"
+          
+          # Enter the new project
           cd "${{ github.event.inputs.repo_name }}"
+
+          # Replace package.json metadata
           npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"
-          npm pkg set license="InnoBridge"
           npm pkg set description="${{ github.event.inputs.description }}"
+          npm pkg set license="InnoBridge"
+
+          # Install its dependencies (tsup, vitest, etc.)
           npm install
       
       - name: Create new GitHub repository

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -1,0 +1,68 @@
+name: Create TypeScript Library Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: 'Name of the TypeScript library'
+        required: true
+        type: string
+      description:
+        description: 'Repository description'
+        required: false
+        default: 'A TypeScript library for LLM clients'
+      author_name:
+        description: 'Author name'
+        required: true
+        type: string
+      author_email:
+        description: 'Author email'
+        required: true
+        type: string
+      private:
+        description: 'Private repository'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  create-typescript-library:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          
+      - name: Scaffold TypeScript library
+        run: |
+          npx tsdx create "${{ github.event.inputs.app_name }}" --template ts --yes
+          cd "${{ github.event.inputs.app_name }}"
+          npm pkg set description="${{ github.event.inputs.description }}"
+          npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"
+          npm install
+      
+      - name: Create new GitHub repository
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
+            -d '{
+                  "name": "${{ github.event.inputs.app_name }}",
+                  "description": "${{ github.event.inputs.description }}",
+                  "private": ${{ github.event.inputs.private }}
+                }' \
+            https://api.github.com/user/repos
+
+      - name: Push to new repository
+        run: |
+          cd "${{ github.event.inputs.app_name }}"
+          git config --global user.email "${{ github.event.inputs.author_email }}"
+          git config --global user.name "${{ github.event.inputs.author_name }}"
+          git init
+          git add .
+          git commit -m "Initialize TypeScript library with tsdx"
+          git branch -M main
+          git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.app_name }}.git
+          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.app_name }}
+          git push -u origin main
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -3,7 +3,11 @@ name: Create TypeScript Library Repository
 on:
   workflow_dispatch:
     inputs:
-      app_name:
+      repo_name:
+        description: 'Name of the GitHub repository'
+        required: true
+        type: string
+      package_name:
         description: 'Name of the TypeScript library'
         required: true
         type: string
@@ -36,8 +40,9 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
-          npx tsdx create "${{ github.event.inputs.app_name }}" --template ts --yes
-          cd "${{ github.event.inputs.app_name }}"
+          npx tsdx create "${{ github.event.inputs.repo_name }}" --template ts --yes
+          cd "${{ github.event.inputs.repo_name }}"
+          npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set description="${{ github.event.inputs.description }}"
           npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"
           npm install
@@ -46,7 +51,7 @@ jobs:
         run: |
           curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
             -d '{
-                  "name": "${{ github.event.inputs.app_name }}",
+                  "name": "${{ github.event.inputs.repo_name }}",
                   "description": "${{ github.event.inputs.description }}",
                   "private": ${{ github.event.inputs.private }}
                 }' \
@@ -54,15 +59,15 @@ jobs:
 
       - name: Push to new repository
         run: |
-          cd "${{ github.event.inputs.app_name }}"
+          cd "${{ github.event.inputs.repo_name }}"
           git config --global user.email "${{ github.event.inputs.author_email }}"
           git config --global user.name "${{ github.event.inputs.author_name }}"
           git init
           git add .
           git commit -m "Initialize TypeScript library with tsdx"
           git branch -M main
-          git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.app_name }}.git
-          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.app_name }}
+          git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
+          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
           git push -u origin main
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -40,11 +40,12 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
+          export npm_config_init_author_name="${{ github.event.inputs.author_name }}"
+          export npm_config_init_author_email="${{ github.event.inputs.author_email }}"
           npx tsdx create "${{ github.event.inputs.repo_name }}" --template basic --y
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set description="${{ github.event.inputs.description }}"
-          npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"
           npm install
       
       - name: Create new GitHub repository

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -40,7 +40,7 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
-          npx create-ts-fast@latest "${{ github.event.inputs.repo_name }}" -- --template universal --yes
+          npx create-ts-fast@latest "${{ github.event.inputs.repo_name }}" --template universal --yes
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"

--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -40,7 +40,7 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
-          npx create-ts-fast@latest "${{ github.event.inputs.package_name }}" -- --template universal
+          npx -y create-ts-fast@latest "${{ github.event.inputs.package_name }}" -- --template universal --yes
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
This pull request introduces four GitHub Actions workflows to automate the creation of repositories for different project types: Node.js backends, React Native apps, TypeScript Electron apps, and TypeScript libraries. Each workflow sets up the project structure, installs dependencies, configures metadata, and pushes the initialized project to a new GitHub repository.

### Workflows for repository creation:

#### Node.js Backend
* Added `.github/workflows/create-node-backend.yaml` to scaffold a Node.js backend with Express, TypeScript, and related tools. It includes steps for setting up a `tsconfig.json`, defining npm scripts, and creating a GitHub repository.

#### React Native App
* Added `.github/workflows/create-react-native-app-repository.yaml` to create a React Native app using Expo. The workflow initializes the app, sets up metadata, and pushes it to a new GitHub repository.

#### TypeScript Electron App
* Added `.github/workflows/create-typescript-electron-repository.yaml` to generate Electron apps with TypeScript. The workflow supports multiple build tools (e.g., Electron Forge, Vite) and customizes the project with `tsconfig.json`, updated `package.json`, and TypeScript conversions.

#### TypeScript Library
* Added `.github/workflows/create-typescript-library.yaml` to scaffold a TypeScript library using a predefined template. It updates the `package.json` metadata, installs dependencies, and initializes a GitHub repository.