### PR TITLE
gitignore eas.json

### DIFF
--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -53,6 +53,7 @@ jobs:
           git config --global user.email "${{ github.event.inputs.author_email }}"
           git config --global user.name "${{ github.event.inputs.author_name }}"
           git init
+          echo 'eas.json' >> .gitignore
           git add .
           git commit -m "Initialize React Native app with Expo"
           git branch -M main


### PR DESCRIPTION
This pull request makes a minor update to the repository initialization workflow by ensuring that the `eas.json` file is ignored by Git during initial commits. This helps prevent accidental commits of configuration files that may contain sensitive or environment-specific information. 

* Added `eas.json` to `.gitignore` in the repository initialization step within `.github/workflows/create-react-native-app-repository.yaml`